### PR TITLE
feat: implement node ack endpoint

### DIFF
--- a/app/api/nodes/ack/route.ts
+++ b/app/api/nodes/ack/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 
-import { requireNodeFromRequest } from '@/app/lib/auth/require-node';
+import { AuthError, requireNodeFromRequest } from '@/app/lib/auth/require-node';
 import { sql } from '@/app/lib/db';
 import {
+  AckValidationError,
   summarizeAckedEvents,
   validateAckEventIds,
   type AckUpdateRow,
@@ -31,15 +32,16 @@ export async function POST(request: Request) {
       ...summarizeAckedEvents(updatedRows),
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unauthorized';
-    const status = message === 'eventIds are required' || message === 'eventIds must be non-empty strings' ? 400 : 401;
+    if (error instanceof AckValidationError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+    }
 
-    return NextResponse.json(
-      {
-        ok: false,
-        error: message,
-      },
-      { status }
-    );
+    if (error instanceof AuthError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 401 });
+    }
+
+    console.error('Unexpected error in node ack:', error);
+
+    return NextResponse.json({ ok: false, error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/lib/auth/require-node.ts
+++ b/app/lib/auth/require-node.ts
@@ -6,11 +6,18 @@ import { extractBearerToken, hashNodeToken } from '@/app/lib/auth/node-tokens';
 import { db } from '@/app/lib/db/client';
 import { nodes, type Node } from '@/db/schema';
 
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
 export async function requireNodeFromRequest(request: Request): Promise<Node> {
   const token = extractBearerToken(request.headers.get('authorization'));
 
   if (!token) {
-    throw new Error('Missing or invalid Authorization header');
+    throw new AuthError('Missing or invalid Authorization header');
   }
 
   const tokenHash = hashNodeToken(token);
@@ -18,11 +25,11 @@ export async function requireNodeFromRequest(request: Request): Promise<Node> {
   const node = result[0];
 
   if (!node) {
-    throw new Error('Invalid node token');
+    throw new AuthError('Invalid node token');
   }
 
   if (node.status !== 'active') {
-    throw new Error('Node is disabled');
+    throw new AuthError('Node is disabled');
   }
 
   return node;

--- a/app/lib/events/ack.ts
+++ b/app/lib/events/ack.ts
@@ -4,36 +4,35 @@ export type AckUpdateRow = {
   id: string;
 };
 
-export function validateAckEventIds(eventIds: unknown): string[] {
-  if (!Array.isArray(eventIds) || eventIds.length === 0) {
-    throw new Error('eventIds are required');
+export class AckValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AckValidationError';
   }
-
-  const normalized = eventIds.map((value) => {
-    if (typeof value !== 'string' || value.trim() === '') {
-      throw new Error('eventIds must be non-empty strings');
-    }
-
-    return value.trim();
-  });
-
-  return normalized;
 }
 
-export function buildAckSql(nodeId: string, eventIds: string[]) {
-  const quotedIds = eventIds.map((id) => `'${id}'`).join(', ');
+export function validateAckEventIds(eventIds: unknown): string[] {
+  if (!Array.isArray(eventIds) || eventIds.length === 0) {
+    throw new AckValidationError('eventIds are required');
+  }
 
-  return `
-    UPDATE events
-    SET
-      status = 'delivered',
-      acked_at = now(),
-      updated_at = now()
-    WHERE node_id = '${nodeId}'
-      AND status = 'leased'
-      AND id IN (${quotedIds})
-    RETURNING id;
-  `;
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const value of eventIds) {
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new AckValidationError('eventIds must be non-empty strings');
+    }
+
+    const trimmed = value.trim();
+
+    if (!seen.has(trimmed)) {
+      seen.add(trimmed);
+      normalized.push(trimmed);
+    }
+  }
+
+  return normalized;
 }
 
 export function summarizeAckedEvents(rows: AckUpdateRow[]) {

--- a/tests/events/node-ack.test.ts
+++ b/tests/events/node-ack.test.ts
@@ -1,32 +1,29 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  AckValidationError,
   validateAckEventIds,
-  buildAckSql,
   type AckUpdateRow,
   summarizeAckedEvents,
 } from '@/app/lib/events/ack';
 
 describe('node ack helpers', () => {
   test('validateAckEventIds rejects empty or invalid payloads', () => {
-    expect(() => validateAckEventIds([])).toThrow('eventIds are required');
-    expect(() => validateAckEventIds([''])).toThrow('eventIds must be non-empty strings');
-    expect(() => validateAckEventIds(['evt_1', '   '])).toThrow('eventIds must be non-empty strings');
+    expect(() => validateAckEventIds([])).toThrow(AckValidationError);
+    expect(() => validateAckEventIds([''])).toThrow(AckValidationError);
+    expect(() => validateAckEventIds(['evt_1', '   '])).toThrow(AckValidationError);
   });
 
   test('validateAckEventIds trims values and preserves order', () => {
     expect(validateAckEventIds([' evt_1 ', 'evt_2'])).toEqual(['evt_1', 'evt_2']);
   });
 
-  test('buildAckSql scopes updates to leased events for the authenticated node', () => {
-    const sql = buildAckSql('node_1', ['evt_1', 'evt_2']);
-
-    expect(sql).toContain("status = 'delivered'");
-    expect(sql).toContain('acked_at = now()');
-    expect(sql).toContain("WHERE node_id = 'node_1'");
-    expect(sql).toContain("AND status = 'leased'");
-    expect(sql).toContain("id IN ('evt_1', 'evt_2')");
-    expect(sql).toContain('RETURNING id');
+  test('validateAckEventIds de-duplicates while preserving first-seen order', () => {
+    expect(validateAckEventIds(['evt_1', 'evt_2', 'evt_1', 'evt_3', 'evt_2'])).toEqual([
+      'evt_1',
+      'evt_2',
+      'evt_3',
+    ]);
   });
 
   test('summarizeAckedEvents returns ack count and ids', () => {


### PR DESCRIPTION
## Summary
- add POST /api/nodes/ack for leased event acknowledgements
- validate ack payload event ids
- mark leased events delivered for the authenticated node only
- add initial Vitest coverage for node ack helpers

## Test Plan
- npm run test:run
- npm run lint
- npm run build

Closes #8