### PR TITLE
feat: add Docker and Nixpacks deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.git
+.gitignore
+README.md
+coverage
+.env*
+.hermes
+AGENTS.md
+CLAUDE.md
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-bookworm-slim AS base
+ENV NEXT_TELEMETRY_DISABLED=1
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build:standalone
+
+FROM base AS runner
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+COPY --from=builder /app/.next/standalone ./
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -1,36 +1,111 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# clawproxy
 
-## Getting Started
+clawproxy is a public webhook relay for private OpenClaw nodes.
+It accepts inbound webhook traffic, stores it durably in Postgres, and lets private nodes pull queued events over authenticated outbound requests.
 
-First, run the development server:
+## Requirements
+
+- Node.js 22+
+- npm
+- Postgres / Neon database
+
+## Local development
+
+Install dependencies:
+
+```bash
+npm ci
+```
+
+Start the dev server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Run tests:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+npm run test:run
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Build for production:
 
-## Learn More
+```bash
+npm run build
+```
 
-To learn more about Next.js, take a look at the following resources:
+## Required environment variables
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+clawproxy currently expects these environment variables at runtime:
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+- `DATABASE_URL`
+- `NEON_AUTH_BASE_URL`
+- `NEON_AUTH_COOKIE_SECRET`
+- `NEXT_PUBLIC_NEON_AUTH_BASE_URL`
 
-## Deploy on Vercel
+Optional deployment variables:
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+- `HOSTNAME` (default `0.0.0.0` for container/server platforms)
+- `PORT` (default `3000`)
+- `NODE_ENV` (set to `production` in deployed environments)
+- `NEXT_TELEMETRY_DISABLED=1` to disable Next.js telemetry in deployments
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Standalone production build
+
+This repo uses Next.js standalone output for deployment builds.
+
+Build the deployable artifact:
+
+```bash
+npm run build:standalone
+```
+
+Start the standalone server directly:
+
+```bash
+node .next/standalone/server.js
+```
+
+## Docker deployment
+
+Build the image:
+
+```bash
+docker build -t clawproxy .
+```
+
+Run it:
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e DATABASE_URL=postgres://user:pass@host:5432/db \
+  -e NEON_AUTH_BASE_URL=https://example-auth.neon.tech \
+  -e NEON_AUTH_COOKIE_SECRET=replace-me \
+  -e NEXT_PUBLIC_NEON_AUTH_BASE_URL=https://example-auth.neon.tech \
+  clawproxy
+```
+
+The container starts with:
+
+```bash
+node server.js
+```
+
+## Nixpacks deployment
+
+A `nixpacks.toml` file is included for Nixpacks-compatible platforms.
+
+Configured build command:
+
+```bash
+npm run build:standalone
+```
+
+Configured start command:
+
+```bash
+node .next/standalone/server.js
+```
+
+Make sure the platform provides the required runtime environment variables listed above.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["100.67.45.56", "127.0.0.1"],
+  output: 'standalone',
+  allowedDevOrigins: ['100.67.45.56', '127.0.0.1'],
 };
 
 export default nextConfig;

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,17 @@
+[variables]
+NODE_ENV = "production"
+HOSTNAME = "0.0.0.0"
+PORT = "3000"
+NEXT_TELEMETRY_DISABLED = "1"
+
+[phases.setup]
+nixPkgs = ["nodejs_22", "npm-10_x"]
+
+[phases.install]
+cmds = ["npm ci"]
+
+[phases.build]
+cmds = ["npm run build:standalone"]
+
+[start]
+cmd = "node .next/standalone/server.js"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:standalone": "next build && node scripts/copy-standalone-assets.mjs",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest",

--- a/scripts/copy-standalone-assets.mjs
+++ b/scripts/copy-standalone-assets.mjs
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const projectRoot = process.cwd();
+const standaloneRoot = path.join(projectRoot, '.next', 'standalone');
+
+function copyIntoStandalone(relativeSourcePath, relativeDestinationPath = relativeSourcePath) {
+  const sourcePath = path.join(projectRoot, relativeSourcePath);
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+
+  const destinationPath = path.join(standaloneRoot, relativeDestinationPath);
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.cpSync(sourcePath, destinationPath, { recursive: true });
+}
+
+copyIntoStandalone('public');
+copyIntoStandalone(path.join('.next', 'static'));

--- a/tests/deployment/deployment-config.test.ts
+++ b/tests/deployment/deployment-config.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import nextConfig from '@/next.config';
+
+const repoRoot = path.resolve(__dirname, '../..');
+
+function readRepoFile(relativePath: string) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('deployment configuration', () => {
+  test('uses Next standalone output for production deployments', () => {
+    expect(nextConfig.output).toBe('standalone');
+  });
+
+  test('defines a standalone build script for deployment platforms', () => {
+    const packageJson = JSON.parse(readRepoFile('package.json')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['build:standalone']).toContain('next build');
+  });
+
+  test('includes a production Dockerfile that runs the standalone server', () => {
+    const dockerfile = readRepoFile('Dockerfile');
+
+    expect(dockerfile).toContain('npm run build:standalone');
+    expect(dockerfile).toContain('COPY --from=builder /app/.next/standalone ./');
+    expect(dockerfile).toContain('CMD ["node", "server.js"]');
+  });
+
+  test('includes a Nixpacks config that builds and starts the standalone server', () => {
+    const nixpacks = readRepoFile('nixpacks.toml');
+
+    expect(nixpacks).toContain('npm run build:standalone');
+    expect(nixpacks).toContain('node .next/standalone/server.js');
+  });
+
+  test('documents deployment environment variables and startup commands in the README', () => {
+    const readme = readRepoFile('README.md');
+
+    expect(readme).toContain('DATABASE_URL');
+    expect(readme).toContain('NEON_AUTH_BASE_URL');
+    expect(readme).toContain('NEON_AUTH_COOKIE_SECRET');
+    expect(readme).toContain('NEXT_PUBLIC_NEON_AUTH_BASE_URL');
+    expect(readme).toContain('npm run build:standalone');
+    expect(readme).toContain('node .next/standalone/server.js');
+    expect(readme).toContain('docker build -t clawproxy .');
+  });
+});


### PR DESCRIPTION
## Summary
- enable Next.js standalone output for deployment builds
- add Dockerfile, Nixpacks config, and a helper script to copy standalone assets
- document required environment variables and deployment commands in the README
- add deployment configuration tests covering the new setup

## Test Plan
- npm run test:run
- npm run build:standalone
- npm run lint

Closes #2